### PR TITLE
Routes the viz.measurementlab.net domain name to the 'viz' service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ npm run build
 
 ```bash
 npm run start
+gcloud app deploy dispatch.yaml
 ```
 
 ## Deploying

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,4 +1,5 @@
 dispatch:
-  # Default module serves simple hostname request.
   - url: "viz.measurementlab.net/*"
     module: viz
+  - url: "data-api.measurementlab.net/*"
+    module: data-api

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,0 +1,4 @@
+dispatch:
+  # Default module serves simple hostname request.
+  - url: "viz.measurementlab.net/*"
+    module: viz


### PR DESCRIPTION
[GAE default routing](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-routed) does not support routing a non "naked" custom domain (e.g., viz.measurementlab.net) to a particular service (formerly known as "module"). In a usual default circumstance you one would specify a custom domain with a wildcard (e.g., *.measurementlab.net), and in such a case when GAE would receive a request for, say, viz.measurementlab.net, it would look for a service named "viz" and if it exists will route the request to it. 

The issue is that we want to allow HTTPS for viz.measurementlab.net, but we do not own a wildcard certificate for measurementlab.net. Specifying a custom domain of viz.measurementlab.net breaks the default routing, yet in GAE's interface you cannot apply a SSL certificate that is good only for viz.measurementlab.net to the wildcard custom domain of *.measurementlab.net.

This PR adds a custom routing rule to a file name dispatch.yaml that overrides the default GAE routing and tells it to route any request to viz.measurementlab.net/* to the "viz" service. This allows us to add a custom domain of viz.measurementlab.net _and_ to apply our SSL certificate to that custom domain..

**NOTE**: This file does _not_ get deploy automatically using the `npm run deploy` command a specified in the README, but instead, for now, must be manually deployed by issuing this command:

`$ gcloud app deploy dispatch.yaml`

This PR also includes an update to the README to indicate this, however we should probably consider folding deployment of dispatch.yaml into the `npm run deploy` process.