### PR TITLE
Changes Stamen map tile URLs to ones that support HTTPS.

### DIFF
--- a/src/server/Html.jsx
+++ b/src/server/Html.jsx
@@ -29,7 +29,7 @@ export default class Html extends Component {
         <script key="vendor" src={assets.javascript.vendor} charSet="UTF-8" />,
         <script key="leaflet" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2/leaflet.js" charSet="UTF-8" />,
         <script key="tangram" src="//mapzen.com/tangram/0.8/tangram.min.js" charSet="UTF-8" />,
-        <script key="stamen" src="//maps.stamen.com/js/tile.stamen.js?v1.3.0" charSet="UTF-8" />,
+        <script key="stamen" src="//stamen-maps.a.ssl.fastly.net/js/tile.stamen.js?v1.3.0" charSet="UTF-8" />,
         <script key="main" src="//localhost:3001/dist/main.js" charSet="UTF-8" />,
       ];
     }
@@ -37,7 +37,7 @@ export default class Html extends Component {
     return [
       <script key="leaflet" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2/leaflet.js" charSet="UTF-8" />,
       <script key="tangram" src="//mapzen.com/tangram/0.8/tangram.min.js" charSet="UTF-8" />,
-      <script key="stamen" src="//maps.stamen.com/js/tile.stamen.js?v1.3.0" charSet="UTF-8" />,
+      <script key="stamen" src="//stamen-maps.a.ssl.fastly.net/js/tile.stamen.js?v1.3.0" charSet="UTF-8" />,
       <script key="main" src={assets.javascript.main} charSet="UTF-8" />,
     ];
   }


### PR DESCRIPTION
The URLs for the Stamen javascript library were not compatible with HTTPS. However, [their website recommends an alternate URL](http://maps.stamen.com/) if you need SSL support. This PR updates our references to the Stamen JS library from the URL they recommend:

 https://stamen-maps.a.ssl.fastly.net/js/tile.stamen.js