### PR TITLE
Make APIROOT config read from environment variable correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       "env": {
         "NODE_PATH": "./src",
         "NODE_ENV": "production",
-        "PORT": 8080
+        "PORT": 8080,
+        "APIROOT": "//data-api-dot-mlab-sandbox.appspot.com"
       }
     },
     "start-dev": {
@@ -67,7 +68,8 @@
     "build": {
       "command": "webpack --verbose --colors --display-error-details --config webpack/prod.config.js",
       "env": {
-        "NODE_ENV": "production"
+        "NODE_ENV": "production",
+        "APIROOT": "//data-api-dot-mlab-sandbox.appspot.com"
       }
     }
   },

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -110,6 +110,10 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.IgnorePlugin(/webpack-stats\.json$/),
     new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"development"',
+        APIROOT: JSON.stringify(process.env.APIROOT),
+      },
       __CLIENT__: true,
       __SERVER__: false,
       __DEVELOPMENT__: true,

--- a/webpack/dll.config.js
+++ b/webpack/dll.config.js
@@ -193,6 +193,10 @@ module.exports = {
 
     new webpack.IgnorePlugin(/webpack-stats\.json$/),
     new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"development"',
+        APIROOT: JSON.stringify(process.env.APIROOT),
+      },
       __CLIENT__: true,
       __SERVER__: false,
       __DEVELOPMENT__: true,

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -63,6 +63,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: '"production"',
+        APIROOT: JSON.stringify(process.env.APIROOT),
       },
 
       __CLIENT__: true,


### PR DESCRIPTION
* Have webpack include the APIROOT value when building
* Have the APIROOT value set in package.json (now needs to be configured here or removed from here-- this is the only place that needs to change for the UI to use a different API URL)