### PR TITLE
Updating APIROOT to point to correct URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "NODE_PATH": "./src",
         "NODE_ENV": "production",
         "PORT": 8080,
-        "APIROOT": "//data-api-dot-mlab-oti.appspot.com"
+        "APIROOT": "//data-api.measurementlab.net/"
       }
     },
     "start-dev": {
@@ -69,7 +69,7 @@
       "command": "webpack --verbose --colors --display-error-details --config webpack/prod.config.js",
       "env": {
         "NODE_ENV": "production",
-        "APIROOT": "//data-api-dot-mlab-oti.appspot.com"
+        "APIROOT": "//data-api.measurementlab.net/"
       }
     }
   },


### PR DESCRIPTION
Updated `package.json` to have the correct default APIROOT.
Now pointing at `data-api.measurementlab.net`
Fixes #272.